### PR TITLE
Add SwiftSyntax as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ let package = Package(
         url: "https://github.com/SwiftDocOrg/SwiftSemantics",
         from: "0.0.1"
     ),
+    .package(
+        url: "https://github.com/apple/swift-syntax.git", 
+        from: "0.50100.0"
+    ),
   ]
 )
 ```


### PR DESCRIPTION
I don't know if you want this, won't be offended if you close it without merging =). But as a user of SwiftSemantics there's no way around using SwiftSyntax, right?