### PR TITLE
Update for Swift 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ name: CI
 on: [push]
 
 jobs:
-  macos:
-    runs-on: macOS-latest
+  # macos:
+  #   runs-on: macOS-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Build and Test
-        run: swift test
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v1
+  #     - name: Build and Test
+  #       run: swift test
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,8 @@ jobs:
   linux:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        swift: ["5.1"]
-
     container:
-      image: swift:${{ matrix.swift }}
+      image: swiftlang/swift:nightly-5.2-xenial
 
     steps:
       - name: Checkout

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": null,
-          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
-          "version": "0.50100.0"
+          "branch": "swift-5.2-DEVELOPMENT-SNAPSHOT-2020-02-12-a",
+          "revision": "75914650fd1f4a8e65c3bf27f2f7599762aae1f5",
+          "version": null
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": "swift-5.2-DEVELOPMENT-SNAPSHOT-2020-02-12-a",
+          "branch": "swift-5.2-DEVELOPMENT-SNAPSHOT-2020-03-09-a",
           "revision": "75914650fd1f4a8e65c3bf27f2f7599762aae1f5",
           "version": null
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": "swift-5.2-DEVELOPMENT-SNAPSHOT-2020-03-09-a",
-          "revision": "75914650fd1f4a8e65c3bf27f2f7599762aae1f5",
-          "version": null
+          "branch": null,
+          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
+          "version": "0.50200.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-syntax.git", .revision("swift-5.2-DEVELOPMENT-SNAPSHOT-2020-03-09-a")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .revision("swift-5.2-DEVELOPMENT-SNAPSHOT-2020-02-12-a")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-syntax.git", .revision("swift-5.2-DEVELOPMENT-SNAPSHOT-2020-02-12-a")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .revision("swift-5.2-DEVELOPMENT-SNAPSHOT-2020-03-09-a")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftSemantics/DeclarationCollector.swift
+++ b/Sources/SwiftSemantics/DeclarationCollector.swift
@@ -20,7 +20,7 @@ import SwiftSyntax
  collector.enumerations.first?.name // "E"
  ```
  */
-open class DeclarationCollector {
+open class DeclarationCollector: SyntaxVisitor {
     /// The collected associated type declarations.
     public private(set) var associatedTypes: [AssociatedType] = []
 
@@ -73,110 +73,108 @@ open class DeclarationCollector {
     public private(set) var variables: [Variable] = []
 
     /// Creates a new declaration collector.
-    public init() {}
-}
+    public override init() {}
 
-// MARK: - SyntaxVisitor
+    // MARK: - SyntaxVisitor
 
-extension DeclarationCollector: SyntaxVisitor {
     /// Called when visiting an `AssociatedtypeDeclSyntax` node
-    public func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
         associatedTypes.append(AssociatedType(node))
         return .skipChildren
     }
 
     /// Called when visiting a `ClassDeclSyntax` node
-    public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         classes.append(Class(node))
         return .visitChildren
     }
 
     /// Called when visiting a `DeinitializerDeclSyntax` node
-    public func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
         deinitializers.append(Deinitializer(node))
         return .skipChildren
     }
 
     /// Called when visiting an `EnumDeclSyntax` node
-    public func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         enumerations.append(Enumeration(node))
         return .visitChildren
     }
 
     /// Called when visiting an `EnumCaseDeclSyntax` node
-    public func visit(_ node: EnumCaseDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: EnumCaseDeclSyntax) -> SyntaxVisitorContinueKind {
         enumerationCases.append(contentsOf: Enumeration.Case.cases(from: node))
         return .skipChildren
     }
 
     /// Called when visiting an `ExtensionDeclSyntax` node
-    public func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
         extensions.append(Extension(node))
         return .visitChildren
     }
 
     /// Called when visiting a `FunctionDeclSyntax` node
-    public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         functions.append(Function(node))
         return .skipChildren
     }
 
     /// Called when visiting an `IfConfigDeclSyntax` node
-    public func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
         conditionalCompilationBlocks.append(ConditionalCompilationBlock(node))
         return .visitChildren
     }
 
     /// Called when visiting an `ImportDeclSyntax` node
-    public func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
         imports.append(Import(node))
         return .skipChildren
     }
 
     /// Called when visiting an `InitializerDeclSyntax` node
-    public func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
         initializers.append(Initializer(node))
         return .skipChildren
     }
 
     /// Called when visiting an `OperatorDeclSyntax` node
-    public func visit(_ node: OperatorDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: OperatorDeclSyntax) -> SyntaxVisitorContinueKind {
         operators.append(Operator(node))
         return .skipChildren
     }
 
     /// Called when visiting a `PrecedenceGroupDeclSyntax` node
-    public func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
         precedenceGroups.append(PrecedenceGroup(node))
         return .skipChildren
     }
 
     /// Called when visiting a `ProtocolDeclSyntax` node
-    public func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
         protocols.append(Protocol(node))
         return .visitChildren
     }
 
     /// Called when visiting a `SubscriptDeclSyntax` node
-    public func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override  func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
         subscripts.append(Subscript(node))
         return .skipChildren
     }
 
     /// Called when visiting a `StructDeclSyntax` node
-    public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         structures.append(Structure(node))
         return .visitChildren
     }
 
     /// Called when visiting a `TypealiasDeclSyntax` node
-    public func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
         typealiases.append(Typealias(node))
         return .skipChildren
     }
 
     /// Called when visiting a `VariableDeclSyntax` node
-    public func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+    public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
         variables.append(contentsOf: Variable.variables(from: node))
         return .skipChildren
     }

--- a/Sources/SwiftSemantics/Declarations/AssociatedType.swift
+++ b/Sources/SwiftSemantics/Declarations/AssociatedType.swift
@@ -20,7 +20,7 @@ public struct AssociatedType: Declaration, Hashable, Codable {
 extension AssociatedType: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: AssociatedtypeDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.associatedtypeKeyword.text.trimmed
         name = node.identifier.text.trimmed

--- a/Sources/SwiftSemantics/Declarations/Class.swift
+++ b/Sources/SwiftSemantics/Declarations/Class.swift
@@ -69,7 +69,7 @@ public struct Class: Declaration, Hashable, Codable {
 extension Class: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: ClassDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.classKeyword.text.trimmed
         name = node.identifier.text.trimmed

--- a/Sources/SwiftSemantics/Declarations/Deinitializer.swift
+++ b/Sources/SwiftSemantics/Declarations/Deinitializer.swift
@@ -17,7 +17,7 @@ public struct Deinitializer: Declaration, Hashable, Codable {
 extension Deinitializer: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: DeinitializerDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.deinitKeyword.text.trimmed
     }

--- a/Sources/SwiftSemantics/Declarations/Enumeration.swift
+++ b/Sources/SwiftSemantics/Declarations/Enumeration.swift
@@ -120,7 +120,7 @@ extension Enumeration.Case: CustomStringConvertible {
 extension Enumeration: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: EnumDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.enumKeyword.text.trimmed
         name = node.identifier.text.trimmed
@@ -143,12 +143,12 @@ extension Enumeration.Case {
             return nil
         }
 
-        attributes = parent.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = parent.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = parent.modifiers?.map { Modifier($0) } ?? []
         keyword = parent.caseKeyword.text.trimmed
 
         name = node.identifier.text.trimmed
         associatedValue = node.associatedValue?.parameterList.map { Function.Parameter($0) }
-        rawValue = node.rawValue?.children.first { $0.isExpr }?.description
+        rawValue = node.rawValue?.value.description.trimmed
     }
 }

--- a/Sources/SwiftSemantics/Declarations/Extension.swift
+++ b/Sources/SwiftSemantics/Declarations/Extension.swift
@@ -52,7 +52,7 @@ public struct Extension: Declaration, Hashable, Codable {
 extension Extension: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: ExtensionDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.extensionKeyword.text.trimmed
         extendedType = node.extendedType.description.trimmed

--- a/Sources/SwiftSemantics/Declarations/Function.swift
+++ b/Sources/SwiftSemantics/Declarations/Function.swift
@@ -148,7 +148,7 @@ public struct Function: Declaration, Hashable, Codable {
 extension Function: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: FunctionDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.funcKeyword.text.trimmed
         identifier = node.identifier.text.trimmed
@@ -161,7 +161,7 @@ extension Function: ExpressibleBySyntax {
 extension Function.Parameter: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: FunctionParameterSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         firstName = node.firstName?.text.trimmed
         secondName = node.secondName?.text.trimmed
         type = node.type?.description.trimmed

--- a/Sources/SwiftSemantics/Declarations/Import.swift
+++ b/Sources/SwiftSemantics/Declarations/Import.swift
@@ -20,7 +20,7 @@ public struct Import: Declaration, Hashable, Codable {
 extension Import: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: ImportDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.importTok.text.trimmed
         kind = node.importKind?.text.trimmed

--- a/Sources/SwiftSemantics/Declarations/Initializer.swift
+++ b/Sources/SwiftSemantics/Declarations/Initializer.swift
@@ -55,7 +55,7 @@ public struct Initializer: Declaration, Hashable, Codable {
 extension Initializer: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: InitializerDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.initKeyword.text.trimmed
         optional = node.optionalMark != nil

--- a/Sources/SwiftSemantics/Declarations/Operator.swift
+++ b/Sources/SwiftSemantics/Declarations/Operator.swift
@@ -132,7 +132,7 @@ public struct Operator: Declaration, Hashable, Codable {
 extension Operator: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: OperatorDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.operatorKeyword.text.trimmed
         name = node.identifier.text.trimmed

--- a/Sources/SwiftSemantics/Declarations/PrecedenceGroup.swift
+++ b/Sources/SwiftSemantics/Declarations/PrecedenceGroup.swift
@@ -139,7 +139,7 @@ extension PrecedenceGroup.Relation: Codable {
 extension PrecedenceGroup: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: PrecedenceGroupDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.precedencegroupKeyword.text.trimmed
         name = node.identifier.text.trimmed
@@ -149,17 +149,14 @@ extension PrecedenceGroup: ExpressibleBySyntax {
         var relations: [Relation] = []
 
         for attribute in node.groupAttributes {
-            switch attribute {
-            case let attribute as PrecedenceGroupAssignmentSyntax:
+            if let attribute = PrecedenceGroupAssignmentSyntax(attribute) {
                 assignment = Bool(attribute)
-            case let attribute as PrecedenceGroupAssociativitySyntax:
+            } else if let attribute = PrecedenceGroupAssociativitySyntax(attribute) {
                 associativity = Associativity(attribute)
-            case let attribute as PrecedenceGroupRelationSyntax:
+            } else if let attribute = PrecedenceGroupRelationSyntax(attribute) {
                 if let relation = Relation(attribute) {
                     relations.append(relation)
                 }
-            default:
-                continue
             }
         }
 

--- a/Sources/SwiftSemantics/Declarations/Protocol.swift
+++ b/Sources/SwiftSemantics/Declarations/Protocol.swift
@@ -34,7 +34,7 @@ public struct Protocol: Declaration, Hashable, Codable {
 extension Protocol: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: ProtocolDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.protocolKeyword.text.trimmed
         name = node.identifier.text.trimmed

--- a/Sources/SwiftSemantics/Declarations/Structure.swift
+++ b/Sources/SwiftSemantics/Declarations/Structure.swift
@@ -64,7 +64,7 @@ public struct Structure: Declaration, Hashable, Codable {
 extension Structure: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: StructDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.structKeyword.text.trimmed
         name = node.identifier.text.trimmed

--- a/Sources/SwiftSemantics/Declarations/Subscript.swift
+++ b/Sources/SwiftSemantics/Declarations/Subscript.swift
@@ -55,14 +55,14 @@ public struct Subscript: Declaration, Hashable, Codable {
 extension Subscript: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: SubscriptDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.subscriptKeyword.text.trimmed
         indices = node.indices.parameterList.map { Function.Parameter($0) }
         genericParameters = node.genericParameterClause?.genericParameterList.map { GenericParameter($0) } ?? []
         returnType = node.result.returnType.description.trimmed
         genericRequirements = GenericRequirement.genericRequirements(from: node.genericWhereClause?.requirementList)
-        accessors = Variable.Accessor.accessors(from: node.accessor as? AccessorBlockSyntax)
+        accessors = Variable.Accessor.accessors(from: node.accessor?.as(AccessorBlockSyntax.self))
     }
 }
 

--- a/Sources/SwiftSemantics/Declarations/Typealias.swift
+++ b/Sources/SwiftSemantics/Declarations/Typealias.swift
@@ -52,7 +52,7 @@ public struct Typealias: Declaration, Hashable, Codable {
 extension Typealias: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: TypealiasDeclSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = node.modifiers?.map { Modifier($0) } ?? []
         keyword = node.typealiasKeyword.text.trimmed
         name = node.identifier.text.trimmed

--- a/Sources/SwiftSemantics/Declarations/Variable.swift
+++ b/Sources/SwiftSemantics/Declarations/Variable.swift
@@ -64,29 +64,23 @@ extension Variable: ExpressibleBySyntax {
             return nil
         }
 
-        attributes = parent.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = parent.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifiers = parent.modifiers?.map { Modifier($0) } ?? []
         keyword = parent.letOrVarKeyword.text.trimmed
         name = node.pattern.description.trimmed
         typeAnnotation = node.typeAnnotation?.type.description.trimmed
         initializedValue = node.initializer?.value.description.trimmed
-        accessors = Accessor.accessors(from: node.accessor as? AccessorBlockSyntax)
+        accessors = Accessor.accessors(from: node.accessor?.as(AccessorBlockSyntax.self))
     }
 }
 
 extension Variable.Accessor: ExpressibleBySyntax {
     public static func accessors(from node: AccessorBlockSyntax?) -> [Variable.Accessor] {
         guard let node = node else { return [] }
-        return node.accessors.compactMap { Variable.Accessor(accessor: $0) }
+        return node.accessors.compactMap { Variable.Accessor($0) }
     }
 
-    /// Creates an instance initialized with the given syntax node.
-    @available(swift, introduced: 0.0.1, deprecated: 0.0.1, message: "Use Variable.Accessor.accessors(from:) instead")
-    public init(_ node: AccessorDeclSyntax) {
-        self.init(accessor: node)!
-    }
-
-    private init?(accessor node: AccessorDeclSyntax) {
+    public init?(_ node: AccessorDeclSyntax) {
         let rawValue = node.accessorKind.text.trimmed
         if rawValue.isEmpty {
             self.kind = nil
@@ -96,7 +90,7 @@ extension Variable.Accessor: ExpressibleBySyntax {
             return nil
         }
 
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         modifier = node.modifier.map { Modifier($0) }
     }
 }

--- a/Sources/SwiftSemantics/ExpressibleBySyntax.swift
+++ b/Sources/SwiftSemantics/ExpressibleBySyntax.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 /// A type that can be initialized with a Swift syntax node.
 public protocol ExpressibleBySyntax {
-    associatedtype Syntax: SwiftSyntax.Syntax
+    associatedtype Syntax: SyntaxProtocol
 
     /// Creates an instance initialized with the given syntax node.
     init?(_ node: Syntax)

--- a/Sources/SwiftSemantics/Extensions/SwiftSyntax+Extensions.swift
+++ b/Sources/SwiftSemantics/Extensions/SwiftSyntax+Extensions.swift
@@ -1,9 +1,9 @@
 import SwiftSyntax
 
-extension Syntax {
-    var context: DeclSyntax? {
-        guard let parent = parent else { return nil }
-        for case let declaration as DeclSyntax in sequence(first: parent, next: { $0.parent }) {
+extension SyntaxProtocol {
+    var context: DeclSyntaxProtocol? {
+        for case let node? in sequence(first: parent, next: { $0?.parent }) {
+            guard let declaration = node.asProtocol(DeclSyntaxProtocol.self) else { continue }
             return declaration
         }
 

--- a/Sources/SwiftSemantics/Supporting Types/GenericParameter.swift
+++ b/Sources/SwiftSemantics/Supporting Types/GenericParameter.swift
@@ -35,7 +35,7 @@ public struct GenericParameter: Hashable, Codable {
 extension GenericParameter: ExpressibleBySyntax {
     /// Creates an instance initialized with the given syntax node.
     public init(_ node: GenericParameterSyntax) {
-        attributes = node.attributes?.compactMap{ $0 as? AttributeSyntax }.map { Attribute($0) } ?? []
+        attributes = node.attributes?.compactMap{ $0.as(AttributeSyntax.self) }.map { Attribute($0) } ?? []
         name = node.name.text.trimmed
         type = node.inheritedType?.description
     }

--- a/Sources/SwiftSemantics/Supporting Types/GenericRequirement.swift
+++ b/Sources/SwiftSemantics/Supporting Types/GenericRequirement.swift
@@ -63,20 +63,19 @@ public struct GenericRequirement: Hashable, Codable {
      */
     public static func genericRequirements(from node: GenericRequirementListSyntax?) -> [GenericRequirement] {
         guard let node = node else { return [] }
-        return node.children.compactMap { GenericRequirement($0) }
+        return node.compactMap { GenericRequirement($0) }
     }
 
-    private init?(_ node: GenericRequirementListSyntax.Element) {
-        switch node {
-        case let node as SameTypeRequirementSyntax:
+    private init?(_ node: GenericRequirementSyntax) {
+        if let node = SameTypeRequirementSyntax(node.body) {
             self.relation = .sameType
             self.leftTypeIdentifier = node.leftTypeIdentifier.description.trimmed
             self.rightTypeIdentifier = node.rightTypeIdentifier.description.trimmed
-        case let node as ConformanceRequirementSyntax:
+        } else if let node = ConformanceRequirementSyntax(node.body) {
             self.relation = .conformance
             self.leftTypeIdentifier = node.leftTypeIdentifier.description.trimmed
             self.rightTypeIdentifier = node.rightTypeIdentifier.description.trimmed
-        default:
+        } else {
             return nil
         }
     }

--- a/Tests/SwiftSemanticsTests/AssociatedTypeTests.swift
+++ b/Tests/SwiftSemanticsTests/AssociatedTypeTests.swift
@@ -5,9 +5,7 @@ import XCTest
 final class AssociatedTypeTests: XCTestCase {
     func testAssociatedTypeDeclaration() throws {
         let source = #"""
-        protocol P {
-            associatedtype T
-        }
+        associatedtype T
         """#
 
         let declarations = try SyntaxParser.declarations(of: AssociatedType.self, source: source)

--- a/Tests/SwiftSemanticsTests/DeclarationCollectorTests.swift
+++ b/Tests/SwiftSemanticsTests/DeclarationCollectorTests.swift
@@ -19,9 +19,9 @@ final class DeclarationCollectorTests: XCTestCase {
 
         """#
 
-        var collector = DeclarationCollector()
+        let collector = DeclarationCollector()
         let tree = try SyntaxParser.parse(source: source)
-        tree.walk(&collector)
+        _ = collector.walk(tree)
 
         XCTAssertEqual(collector.imports.count, 1)
         XCTAssertEqual(collector.imports.first?.pathComponents, ["UIKit"])

--- a/Tests/SwiftSemanticsTests/Extensions/SyntaxParser+Declarations.swift
+++ b/Tests/SwiftSemanticsTests/Extensions/SyntaxParser+Declarations.swift
@@ -4,9 +4,9 @@ import struct SwiftSemantics.Protocol
 
 extension SyntaxParser {
     static func declarations<T: Declaration>(of type: T.Type, source: String) throws -> [T] {
-        var collector = DeclarationCollector()
+        let collector = DeclarationCollector()
         let tree = try parse(source: source)
-        tree.walk(&collector)
+        _ = collector.walk(tree)
 
         switch type {
         case is AssociatedType.Type:


### PR DESCRIPTION
This PR updates SwiftSyntax to a more recent version that targets the latest Swift 5.2 development release. To be merged once that becomes generally available.