### PR TITLE
fix sample code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class ViewController: UIViewController, UITableViewDelegate {
 
 var collector = DeclarationCollector()
 let tree = try SyntaxParser.parse(source: source)
-tree.walk(&collector)
+collector.walk(tree)
 
 // Import declarations
 collector.imports.first?.pathComponents // ["UIKit"]


### PR DESCRIPTION
I believe the current README example code `tree.walk` is incorrect, and uses a method that was removed in [version 5.2 of swift-syntax](https://github.com/apple/swift-syntax/blob/master/Changelog.md#swift-52). Trying to run similar code in a new project results in "error: value of type 'SourceFileSyntax' has no member 'walk'". Changing it to `collector.walk(tree)` seems to have the expected result.