### PR TITLE
Fix typo in documentation comments.

### DIFF
--- a/Sources/SwiftSemantics/Declarations/Class.swift
+++ b/Sources/SwiftSemantics/Declarations/Class.swift
@@ -55,7 +55,7 @@ public struct Class: Declaration, Hashable, Codable {
      the following declaration of class `C`
      has a single requirement
      that its generic parameter identified as `"T"`
-     conforms to the type identified as `"Hahable"`:
+     conforms to the type identified as `"Hashable"`:
 
      ```swift
      class C<T> where T: Hashable {}

--- a/Sources/SwiftSemantics/Declarations/Enumeration.swift
+++ b/Sources/SwiftSemantics/Declarations/Enumeration.swift
@@ -53,7 +53,7 @@ public struct Enumeration: Declaration, Hashable, Codable {
      the following declaration of enumeration `E`
      has a single requirement
      that its generic parameter identified as `"T"`
-     conforms to the type identified as `"Hahable"`:
+     conforms to the type identified as `"Hashable"`:
 
      ```swift
      enum E<T> where T: Hashable {}

--- a/Sources/SwiftSemantics/Declarations/Extension.swift
+++ b/Sources/SwiftSemantics/Declarations/Extension.swift
@@ -37,7 +37,7 @@ public struct Extension: Declaration, Hashable, Codable {
      the following conditional extension on structure S
      has a single requirement
      that its generic parameter identified as `"T"`
-     conforms to the type identified as `"Hahable"`:
+     conforms to the type identified as `"Hashable"`:
 
      ```swift
      struct S<T> {}

--- a/Sources/SwiftSemantics/Declarations/Function.swift
+++ b/Sources/SwiftSemantics/Declarations/Function.swift
@@ -38,7 +38,7 @@ public struct Function: Declaration, Hashable, Codable {
      the following declaration of function `f`
      has a single requirement
      that its generic parameter identified as `"T"`
-     conforms to the type identified as `"Hahable"`:
+     conforms to the type identified as `"Hashable"`:
 
      ```swift
      func f<T>(value: T) where T: Hashable {}

--- a/Sources/SwiftSemantics/Declarations/Initializer.swift
+++ b/Sources/SwiftSemantics/Declarations/Initializer.swift
@@ -41,7 +41,7 @@ public struct Initializer: Declaration, Hashable, Codable {
      the following initializer declaration
      has a single requirement
      that its generic parameter identified as `"T"`
-     conforms to the type identified as `"Hahable"`:
+     conforms to the type identified as `"Hashable"`:
 
      ```swift
      init<T>(value: T) where T: Hashable {}

--- a/Sources/SwiftSemantics/Declarations/Structure.swift
+++ b/Sources/SwiftSemantics/Declarations/Structure.swift
@@ -50,7 +50,7 @@ public struct Structure: Declaration, Hashable, Codable {
      the following declaration of structure `S`
      has a single requirement
      that its generic parameter identified as `"T"`
-     conforms to the type identified as `"Hahable"`:
+     conforms to the type identified as `"Hashable"`:
 
      ```swift
      struct S<T> where T: Hashable {}

--- a/Sources/SwiftSemantics/Declarations/Subscript.swift
+++ b/Sources/SwiftSemantics/Declarations/Subscript.swift
@@ -35,7 +35,7 @@ public struct Subscript: Declaration, Hashable, Codable {
      the following subscript declaration
      has a single requirement
      that its generic parameter identified as `"T"`
-     conforms to the type identified as `"Hahable"`:
+     conforms to the type identified as `"Hashable"`:
 
      ```swift
      subscript<T>(value: T) where T: Hashable {}


### PR DESCRIPTION
This fixes a typo in the protocol name (missing s).