### PR TITLE
Update Swift 5.4 package manifest to use tagged swift-syntax version 

### DIFF
--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -16,7 +16,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "SwiftSyntax",
                  url: "https://github.com/apple/swift-syntax.git",
-                 .revision("release/5.4")),
+                 .exact("0.50400.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Related to https://github.com/apple/swift-syntax/pull/279

(Thanks, @akyrtzi!)