### PR TITLE
Update Package@swift-5.4.swift

### DIFF
--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -16,7 +16,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "SwiftSyntax",
                  url: "https://github.com/apple/swift-syntax.git",
-                 .exact("0.50400.0")),
+                 .revision("release/5.4")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Track the 5.4 branch instead of a tag.  This matches what swift-doc currently has and picks up the necessary change to allow building this on Windows.